### PR TITLE
Add questionnaire models and database session helper

### DIFF
--- a/libs/common/__init__.py
+++ b/libs/common/__init__.py
@@ -5,3 +5,15 @@
 
 __version__ = "1.0.0"
 
+from .database import get_db
+from .questionnaire_models import Sport, Team, UserSportPreference, UserTeamPreference
+
+__all__ = [
+    "__version__",
+    "get_db",
+    "Sport",
+    "Team",
+    "UserSportPreference",
+    "UserTeamPreference",
+]
+

--- a/libs/common/questionnaire_models.py
+++ b/libs/common/questionnaire_models.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2024 Sports Media Platform
+# Licensed under the MIT License
+
+"""Questionnaire related SQLAlchemy models.
+
+These models store available sports and teams as well as user
+preferences. They are separated from the main ``database`` module to
+keep concerns modular while still sharing the same SQLAlchemy ``Base``.
+"""
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from .database import Base
+
+
+class Sport(Base):
+    """Represents a sport that users can select."""
+
+    __tablename__ = "sports"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(50), unique=True, nullable=False)
+    display_name = Column(String(100), nullable=False)
+    description = Column(Text)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=func.now())
+
+    # Relationships
+    teams = relationship("Team", back_populates="sport")
+
+
+class Team(Base):
+    """Represents a team within a specific sport."""
+
+    __tablename__ = "teams"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    sport_id = Column(Integer, ForeignKey("sports.id"), nullable=False)
+    name = Column(String(100), nullable=False)
+    display_name = Column(String(100), nullable=False)
+    city = Column(String(100))
+    state = Column(String(100))
+    country = Column(String(100))
+    league = Column(String(100))
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=func.now())
+
+    # Relationships
+    sport = relationship("Sport", back_populates="teams")
+    preferences = relationship("UserTeamPreference", back_populates="team")
+
+
+class UserSportPreference(Base):
+    """User's interest level in a sport."""
+
+    __tablename__ = "user_sport_preferences"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(String(255), nullable=False, index=True)
+    sport_id = Column(Integer, ForeignKey("sports.id"), nullable=False, index=True)
+    interest_level = Column(Integer, nullable=False)
+    created_at = Column(DateTime, default=func.now())
+
+    # Relationships
+    sport = relationship("Sport")
+
+
+class UserTeamPreference(Base):
+    """User's interest level in a team."""
+
+    __tablename__ = "user_team_preferences"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(String(255), nullable=False, index=True)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=False, index=True)
+    interest_level = Column(Integer, nullable=False)
+    created_at = Column(DateTime, default=func.now())
+
+    # Relationships
+    team = relationship("Team", back_populates="preferences")
+
+
+__all__ = [
+    "Sport",
+    "Team",
+    "UserSportPreference",
+    "UserTeamPreference",
+]
+


### PR DESCRIPTION
## Summary
- add Sport, Team, UserSportPreference and UserTeamPreference models for questionnaire APIs
- provide synchronous SQLAlchemy `get_db` session generator
- expose database helper and models through `libs.common`

## Testing
- `pytest` *(fails: aioredis TimeoutError, missing DATABASE_URL)*


------
https://chatgpt.com/codex/tasks/task_e_68b1ed20bd8c8321844357ecf57c5691