### PR TITLE
Align proxy budget stats with configuration

### DIFF
--- a/libs/ingestion/crawler.py
+++ b/libs/ingestion/crawler.py
@@ -156,9 +156,9 @@ class ProxyManager:
     def get_proxy_stats(self) -> Dict[str, Any]:
         """Get proxy usage statistics"""
         return {
-            "daily_usage_usd": self.daily_usage,
-            "daily_budget_usd": self.settings.evomi.daily_budget_usd,
-            "budget_remaining": self.settings.evomi.daily_budget_usd - self.daily_usage,
+            "daily_usage": self.daily_usage,
+            "daily_budget": self.settings.evomi.daily_budget,
+            "budget_remaining": self.settings.evomi.daily_budget - self.daily_usage,
             "proxy_stats": self.proxy_stats
         }
 


### PR DESCRIPTION
## Summary
- Replace `daily_budget_usd` references with `daily_budget` in proxy stats
- Return `daily_usage`, `daily_budget`, and `budget_remaining` keys for clarity

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aioredis')*


------
https://chatgpt.com/codex/tasks/task_e_68b1ef94e5c083218dd2f14ef87726b0