### PR TITLE
Add basic ApiResponse integration test

### DIFF
--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -1,0 +1,7 @@
+from libs.api.response import ApiResponse
+
+
+def test_api_response_instantiation():
+    resp = ApiResponse(success=True, data={"foo": "bar"})
+    assert resp.success is True
+    assert resp.data == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- add test verifying ApiResponse helper structure

## Testing
- `pytest tests/test_api_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1f5e56c3883219c08b67baad1c445