### PR TITLE
fix: handle missing Clerk config and init validator state

### DIFF
--- a/libs/auth/clerk_config.py
+++ b/libs/auth/clerk_config.py
@@ -130,11 +130,14 @@ class ClerkConfig(BaseSettings):
     
     def is_production(self) -> bool:
         """Check if running in production mode.
-        
+
         Returns:
-            bool: True if using live keys, False for test keys
+            bool: True if using live keys, False otherwise.
+
+        Safely handles missing publishable key by treating it as non-production.
         """
-        return self.clerk_publishable_key.startswith('pk_live_')
+        key = self.clerk_publishable_key or ""
+        return key.startswith("pk_live_")
     
     def validate_configuration(self) -> bool:
         """Validate the complete configuration.

--- a/libs/auth/middleware.py
+++ b/libs/auth/middleware.py
@@ -101,6 +101,9 @@ class ClerkTokenValidator:
             timeout=self.config.request_timeout,
             limits=httpx.Limits(max_connections=10, max_keepalive_connections=5)
         )
+        # Track in-flight JWKS fetches and per-URL locks for cleanup
+        self._pending_requests: Dict[str, asyncio.Task] = {}
+        self._jwks_locks: Dict[str, asyncio.Lock] = {}
     
     async def _fetch_jwks(self, jwks_url: str) -> Dict[str, Any]:
         """Fetch JWKS from Clerk's endpoint with caching and concurrency safety."""


### PR DESCRIPTION
## Summary
- make `ClerkConfig.is_production` resilient to missing publishable keys
- ensure `reset_clerk_config` properly clears global state
- initialize pending request and lock tracking in `ClerkTokenValidator`

## Testing
- `CLERK_CLERK_PUBLISHABLE_KEY=pk_test_dummy DATABASE_URL=sqlite:///test.db DEEPSEEK_API_KEY=dummy EVOMI_PROXY_USER=user EVOMI_PROXY_PASS=pass SECURITY_JWT_SECRET_KEY=secret pytest tests/unit/test_jwks_concurrency.py` *(fails: multiple JWKS concurrency assertions and AttributeErrors)*

------
https://chatgpt.com/codex/tasks/task_e_68b24822e5d48321b7bd9f0d16cf73f0