### PR TITLE
fix: ignore legacy redis kwargs in DuplicateDetector

### DIFF
--- a/libs/ingestion/extractor.py
+++ b/libs/ingestion/extractor.py
@@ -306,6 +306,19 @@ class DuplicateDetector(NearDuplicateDetector):
     """
 
     def __init__(self, _redis_client=None, *args, **kwargs):  # noqa: D401 - see class docstring
+        # Remove legacy Redis client keyword arguments that are not
+        # supported by ``NearDuplicateDetector``. This preserves backward
+        # compatibility with callers that previously instantiated the
+        # detector with parameters like ``redis_client=...``.
+        for key in (
+            "redis_client",
+            "redis",
+            "client",
+            "redis_conn",
+            "redis_connection",
+        ):
+            kwargs.pop(key, None)
+
         super().__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- strip legacy redis-related keywords before delegating to `NearDuplicateDetector`

## Testing
- `pytest tests/test_golden_corpus.py::test_golden_corpus_extraction -q` *(fails: DatabaseSettings.url missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b27c7d30688321a9f3753015b9558a