### PR TITLE
Add update_sport_ranking alias

### DIFF
--- a/apps/api/questionnaire_routes.py
+++ b/apps/api/questionnaire_routes.py
@@ -361,6 +361,20 @@ async def save_sport_rankings(
     # Return the updated rankings
     return ApiResponse(success=True, data=sport_rankings)
 
+
+@router.put(
+    "/sports/ranking",
+    response_model=ApiResponse[list[str]],
+)
+async def update_sport_ranking(
+    request: SportRankingRequest,
+    credentials: HTTPAuthorizationCredentials = Depends(require_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Alias for ``save_sport_rankings`` using HTTP PUT."""
+
+    return await save_sport_rankings(request, credentials, db)
+
 @router.post(
     "/teams/preferences",
     response_model=ApiResponse[list[UserTeamPreferenceResponse]],

--- a/libs/common/questionnaire_models.py
+++ b/libs/common/questionnaire_models.py
@@ -12,7 +12,29 @@ from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, T
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
+from pydantic import BaseModel
+
 from .database import Base
+
+
+class SportRankingRequest(BaseModel):
+    """Request model for updating sport rankings."""
+
+    sport_rankings: list[str]
+
+
+class FavoriteTeamsRequest(BaseModel):
+    """Request model for saving favorite teams."""
+
+    team_selections: list[dict]
+
+
+class UserQuestionnaireStatus(BaseModel):
+    """Simple questionnaire status representation used in tests."""
+
+    user_id: str
+    is_completed: bool
+    current_step: int
 
 
 class Sport(Base):
@@ -88,5 +110,8 @@ __all__ = [
     "Team",
     "UserSportPreference",
     "UserTeamPreference",
+    "SportRankingRequest",
+    "FavoriteTeamsRequest",
+    "UserQuestionnaireStatus",
 ]
 


### PR DESCRIPTION
## Summary
- expose update_sport_ranking route as PUT alias of save_sport_rankings
- add request models for questionnaire tests

## Testing
- `pytest tests/unit/test_questionnaire_routes.py::TestQuestionnaireRoutes::test_update_sport_ranking_success -q` *(fails: AttributeError: <module 'apps.api.questionnaire_routes' from '/workspace/Corner-League-Bot/apps/api/questionnaire_routes.py'> does not have the attribute 'get_current_user_id')*

------
https://chatgpt.com/codex/tasks/task_e_68b262b3e5d08321b3ab6707265c829c