### PR TITLE
Expose DuplicateDetector via ingestion package

### DIFF
--- a/libs/ingestion/__init__.py
+++ b/libs/ingestion/__init__.py
@@ -5,3 +5,24 @@
 
 __version__ = "1.0.0"
 
+from .extractor import (
+    CanonicalURLExtractor,
+    ContentExtractor,
+    ContentHasher,
+    DuplicateDetector,
+    ExtractionPipeline,
+    NearDuplicateDetector,
+    URLCanonicalizer,
+)
+
+__all__ = [
+    "CanonicalURLExtractor",
+    "ContentExtractor",
+    "ContentHasher",
+    "DuplicateDetector",
+    "ExtractionPipeline",
+    "NearDuplicateDetector",
+    "URLCanonicalizer",
+    "__version__",
+]
+


### PR DESCRIPTION
## Summary
- re-export canonicalization and deduplication helpers, including DuplicateDetector, from `libs.ingestion`

## Testing
- `pytest tests/test_golden_corpus.py::test_golden_corpus_extraction -q` *(fails: Clerk configuration error: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68b262adc07c8321a4e72810f241c8c7