### PR TITLE
fix: handle sport ID strings when fetching teams

### DIFF
--- a/frontend/client/src/hooks/useQuestionnaire.ts
+++ b/frontend/client/src/hooks/useQuestionnaire.ts
@@ -386,12 +386,12 @@ export function useTeamsForSports(sportIds: string[]) {
   
   // Convert sportIds to strings for API calls
   const validSportIds = (sportIds || [])
-    .filter(sportId => 
-      sportId && 
-      typeof sportId === 'number' && 
-      !isNaN(sportId)
+    .filter((sportId) =>
+      typeof sportId === 'string'
+        ? sportId.trim() !== ''
+        : sportId != null && !Number.isNaN(sportId)
     )
-    .map(sportId => sportId.toString());
+    .map((sportId) => sportId.toString());
   
   return useQuery({
     queryKey: ['teams-for-sports', validSportIds],


### PR DESCRIPTION
## Summary
- handle sport ID strings when fetching teams for questionnaire

## Testing
- `pytest tests/unit/test_questionnaire_routes.py::TestQuestionnaireRoutes::test_get_available_sports_success -q` *(fails: Clerk configuration error)*

------
https://chatgpt.com/codex/tasks/task_e_68b2991aeac48321887d441eca50e321