### PR TITLE
Fix team preference payload in questionnaire

### DIFF
--- a/frontend/client/src/hooks/useQuestionnaire.ts
+++ b/frontend/client/src/hooks/useQuestionnaire.ts
@@ -65,11 +65,9 @@ interface SportRankingRequest {
   sport_rankings: string[];
 }
 
-interface FavoriteTeamsRequest {
-  team_selections: Array<{
-    team_id: string;
-    sport_id: string;
-  }>;
+interface TeamPreferenceRequest {
+  team_id: string;
+  interest_level: number;
 }
 
 // Use relative API path - Vite proxy will redirect to backend
@@ -336,7 +334,7 @@ export function useSaveTeamPreferences() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (data: FavoriteTeamsRequest) => {
+    mutationFn: async (data: TeamPreferenceRequest[]) => {
       const token = await getToken();
       const response = await fetch(`${API_BASE}/teams/preferences`, {
         method: 'POST',

--- a/frontend/client/src/pages/questionnaire.tsx
+++ b/frontend/client/src/pages/questionnaire.tsx
@@ -176,8 +176,11 @@ export default function QuestionnairePage() {
     try {
       setSubmitting(true);
       setError(null);
-
-      await saveTeamPreferences.mutateAsync({ team_selections: selectedTeams });
+      const teamPreferences = selectedTeams.map(team => ({
+        team_id: team.team_id,
+        interest_level: 3,
+      }));
+      await saveTeamPreferences.mutateAsync(teamPreferences);
       setCurrentStep('completed');
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to save team preferences';

--- a/frontend/client/src/types/api.ts
+++ b/frontend/client/src/types/api.ts
@@ -521,13 +521,14 @@ export interface components {
             /** Sport Ids */
             sport_ids: string[];
         };
-        /** FavoriteTeamsRequest */
-        FavoriteTeamsRequest: {
-            /** Team Selections */
-            team_selections: {
-                [key: string]: unknown;
-            }[];
+        /** TeamPreferenceRequest */
+        TeamPreferenceRequest: {
+            team_id: string;
+            interest_level: number;
         };
+
+        /** FavoriteTeamsRequest */
+        FavoriteTeamsRequest: components["schemas"]["TeamPreferenceRequest"][];
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */

--- a/libs/common/questionnaire_models.py
+++ b/libs/common/questionnaire_models.py
@@ -24,10 +24,18 @@ class SportRankingRequest(BaseModel):
     sport_rankings: list[str]
 
 
+
+class TeamPreferenceRequest(BaseModel):
+    """Request model for a single team preference."""
+
+    team_id: str
+    interest_level: int
+
+
 class FavoriteTeamsRequest(BaseModel):
     """Request model for saving favorite teams."""
 
-    team_selections: list[dict]
+    team_selections: list[TeamPreferenceRequest]
 
 
 class UserQuestionnaireStatus(BaseModel):

--- a/tests/unit/test_questionnaire_routes.py
+++ b/tests/unit/test_questionnaire_routes.py
@@ -14,10 +14,10 @@ from apps.api.questionnaire_routes import (
     update_sport_ranking,
 )
 from libs.common.questionnaire_models import (
-    FavoriteTeamsRequest,
     Sport,
     SportRankingRequest,
     Team,
+    TeamPreferenceRequest,
     UserQuestionnaireStatus,
     UserSportPreference,
     UserTeamPreference,
@@ -151,27 +151,23 @@ class TestQuestionnaireRoutes:
         """Test successful team preferences save."""
         db_manager, mock_session = mock_db_manager
 
-        # Mock request and user
-        mock_request = MagicMock(spec=Request)
-        mock_request.state.user = {"sub": "user123"}
-
         mock_credentials = MagicMock(spec=HTTPAuthorizationCredentials)
+        mock_credentials.user_id = "user123"
 
-        request_data = FavoriteTeamsRequest(team_selections=[
-            {"sport_id": "1", "team_id": "1"},
-            {"sport_id": "1", "team_id": "2"}
-        ])
+        request_data = [
+            TeamPreferenceRequest(team_id="1", interest_level=3),
+            TeamPreferenceRequest(team_id="2", interest_level=3)
+        ]
 
         # Mock database operations
         mock_session.execute.return_value = MagicMock()
         mock_session.commit.return_value = None
 
         # Execute
-        with patch("apps.api.questionnaire_routes.get_current_user_id", return_value="user123"):
-            result = await save_team_preferences(mock_request, request_data, db_manager, mock_credentials)
+        result = await save_team_preferences(request_data, mock_credentials, mock_session)
 
         # Assert
-        assert result["message"] == "Team preferences saved successfully"
+        assert result.success is True
         assert mock_session.commit.called
 
     async def test_get_user_preferences_success(self, mock_db_manager):


### PR DESCRIPTION
## Summary
- ensure team preferences send `team_id` and `interest_level` array
- update questionnaire hooks, types, and request models
- adjust unit test for new team preference schema

## Testing
- `pre-commit run --files frontend/client/src/hooks/useQuestionnaire.ts frontend/client/src/pages/questionnaire.tsx frontend/client/src/types/api.ts libs/common/questionnaire_models.py tests/unit/test_questionnaire_routes.py`
- `pytest tests/unit/test_questionnaire_routes.py::TestQuestionnaireRoutes::test_save_team_preferences_success -q` *(fails: Clerk configuration error: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68b36f6cac20832189e37005ee15c2e8