### PR TITLE
fix: sync questionnaire team selections with favorite teams

### DIFF
--- a/apps/api/questionnaire_routes.py
+++ b/apps/api/questionnaire_routes.py
@@ -571,7 +571,7 @@ async def save_team_preferences(
             update_user_query = text("""
                 UPDATE users
                 SET favorite_teams = :favorite_teams, updated_at = NOW()
-                WHERE id = :user_id
+                WHERE user_id = :user_id
             """)
             await db.execute(update_user_query, {
                 "user_id": user_id,


### PR DESCRIPTION
## Summary
- ensure questionnaire team preferences update user's favorite_teams using user_id so Manage Account reads them

## Testing
- `pytest tests/unit/test_questionnaire_routes.py::TestQuestionnaireRoutes::test_save_team_preferences_success -q` *(fails: Clerk configuration error: 'NoneType' object has no attribute 'startswith')*


------
https://chatgpt.com/codex/tasks/task_e_68b5efdfd2648321b4edb7a1107a23e0