### PR TITLE
Defer Clerk auth bearer initialization

### DIFF
--- a/libs/auth/decorators.py
+++ b/libs/auth/decorators.py
@@ -46,7 +46,7 @@ class MockCredentials:
 
 
 def require_auth(
-    credentials: EnhancedCredentials = Depends(get_clerk_bearer())
+    credentials: EnhancedCredentials = Depends(get_clerk_bearer)
 ) -> EnhancedCredentials:
     """Dependency that requires valid authentication.
 


### PR DESCRIPTION
## Summary
- avoid calling `get_clerk_bearer` during import in auth decorator

## Testing
- `pytest -q` *(fails: SyntaxError in `libs/ingestion/extractor.py`; ModuleNotFoundError: feedparser; missing pytest markers `asyncio`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fbf0c1fc83218ae5b32d1d6ded45