### PR TITLE
Remove unsupported asyncio_mode config for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,6 @@ ignore_missing_imports = true
 minversion = "7.0"
 addopts = "-ra -q --strict-markers --strict-config"
 testpaths = ["tests"]
-asyncio_mode = "auto"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",


### PR DESCRIPTION
## Summary
- remove deprecated `asyncio_mode` setting from pytest configuration

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest -q` *(fails: ValueError: Clerk configuration error: 'NoneType' object has no attribute 'startswith')*

------
https://chatgpt.com/codex/tasks/task_e_68b5fbf231308321949e225c8dbd7bf7